### PR TITLE
Add option to enable non-free modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,19 @@ The following command both runs all the steps of the conan file, and publishes t
 
 
 ### Available Options
-| Option        | Default | Possible Values  |
-| ------------- |:----------------- |:------------:|
-| shared      | False |  [True, False] |
-| fPIC      | True |  [True, False] |
-| contrib      | False |  [True, False] |
-| jpeg      | True |  [True, False] |
-| tiff      | True |  [True, False] |
-| webp      | True |  [True, False] |
-| png      | True |  [True, False] |
-| jasper      | True |  [True, False] |
-| openexr      | True |  [True, False] |
-| gtk      | 3 |  [None, 2, 3] |
+| Option        | Default | Possible Values  | Description |
+| ------------- |:----------------- |:------------:| ----- |
+| shared      | False |  [True, False] | |
+| fPIC      | True |  [True, False] | |
+| contrib      | False |  [True, False] | |
+| jpeg      | True |  [True, False] | |
+| tiff      | True |  [True, False] | |
+| webp      | True |  [True, False] | |
+| png      | True |  [True, False] | |
+| jasper      | True |  [True, False] | |
+| openexr      | True |  [True, False] | |
+| gtk      | 3 |  [None, 2, 3] | |
+| nonfree | False | [True, False] | Include non-free features in the build. This is required to use patented algorithms such as SIFT, SURF or KinectFusion. |
 
 
 ## Add Remote

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,8 @@ class OpenCVConan(ConanFile):
                "png": [True, False],
                "jasper": [True, False],
                "openexr": [True, False],
-               "gtk": [None, 2, 3]}
+               "gtk": [None, 2, 3],
+               "nonfree": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "contrib": False,
@@ -31,7 +32,8 @@ class OpenCVConan(ConanFile):
                        "png": True,
                        "jasper": True,
                        "openexr": True,
-                       "gtk": 3}
+                       "gtk": 3,
+                       "nonfree": False}
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     description = "OpenCV (Open Source Computer Vision Library) is an open source computer vision and machine " \
@@ -160,6 +162,9 @@ class OpenCVConan(ConanFile):
 
         if self.options.contrib:
             cmake.definitions['OPENCV_EXTRA_MODULES_PATH'] = os.path.join(self.build_folder, 'contrib', 'modules')
+
+        if self.options.nonfree:
+            cmake.definitions['OPENCV_ENABLE_NONFREE'] = True
 
         cmake.configure(build_folder=self._build_subfolder)
         return cmake


### PR DESCRIPTION
Some `contrib` modules of OpenCV (`rgbd`, `xphoto`, `xfeatures2d`) contain non-free code, usually patented, which is not included in the build by default. For example, the widely used SIFT and SURF
algorithms for feature detection are patented and therefore not included unless the `OPENCV_ENABLE_NONFREE` flag is set (see <https://docs.opencv.org/4.0.1/d2/dca/group__xfeatures2d__nonfree.html>).

I suggest adding a flag to this recipe allowing users to enable these features if they wish.