### PR TITLE
Adding missing dnn library to opencv_libs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -299,7 +299,8 @@ class OpenCVConan(ConanFile):
                        "imgcodecs",
                        "objdetect",
                        "imgproc",
-                       "core"]
+                       "core",
+                       "dnn"]
 
         if self.settings.os != 'Android':
             # gapi depends on ade but ade disabled for Android


### PR DESCRIPTION
The dnn lib for opencv was missing in cpp_info.libs