### PR TITLE
update cmake variables and flags

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -189,10 +189,8 @@ class OpenCVConan(ConanFile):
         cmake.definitions['BUILD_TESTS'] = False
         cmake.definitions['BUILD_PERF_TESTS'] = False
         cmake.definitions['WITH_IPP'] = False
-        cmake.definitions['BUILD_IPP_IW'] = False
+        cmake.definitions['BUILD_JAVA'] = False
         cmake.definitions['BUILD_opencv_apps'] = False
-        cmake.definitions['BUILD_opencv_java'] = False
-        cmake.definitions['BUILD_opencv_python'] = False
         cmake.definitions['BUILD_opencv_python2'] = False
         cmake.definitions['BUILD_opencv_python3'] = False
         cmake.definitions['INSTALL_C_EXAMPLES'] = False
@@ -220,7 +218,6 @@ class OpenCVConan(ConanFile):
         cmake.definitions['BUILD_TBB'] = False
         cmake.definitions['BUILD_IPP_IW'] = False
         cmake.definitions['BUILD_ITT'] = False
-        cmake.definitions['BUILD_JPEG_TURBO_DISABLE'] = True
         cmake.definitions['BUILD_PROTOBUF'] = False
         cmake.definitions['PROTOBUF_UPDATE_FILES'] = False
 


### PR DESCRIPTION
- redundant definition of `BUILD_IPP_IW`
- `BUILD_JAVA` is the flag for building java support accoriding to https://github.com/opencv/opencv/blob/576644a19705f3ee762d168a4ab780102fb824b7/CMakeLists.txt#L434
- `BUILD_opencv_python` is no longer available. only `BUILD_opencv_python2` and `BUILD_opencv_python3` (See: https://github.com/opencv/opencv/blob/576644a19705f3ee762d168a4ab780102fb824b7/CMakeLists.txt#L1585)
- `BUILD_JPEG_TURBO_DISABLE` was removed in OpenCV4 https://github.com/opencv/opencv/blob/576644a19705f3ee762d168a4ab780102fb824b7/3rdparty/readme.txt#L22