### PR TITLE
Fix linking error

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -435,9 +435,9 @@ class OpenCVConan(ConanFile):
                        "flann",
                        "imgcodecs",
                        "objdetect",
+                       "dnn",
                        "imgproc",
-                       "core",
-                       "dnn"]
+                       "core"]
 
         if not self.options.protobuf:
             opencv_libs.remove("dnn")


### PR DESCRIPTION
Fix libs linking order, old one caused undefined function error in dnn module during linking stage with opencv on linux with gcc 5