### PR TITLE
Add quirc to cpp_info.libs for static builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -543,5 +543,7 @@ class OpenCVConan(ConanFile):
                 os.path.join('lib', 'opencv4', '3rdparty'))
             if not self.options.shared:
                 self.cpp_info.libs.append('ade')
+                if self.options.quirc:
+                    self.cpp_info.libs.append('quirc%s' % suffix)
         if self.options.contrib and self.options.eigen and self.options.glog and self.options.gflags:
             self.cpp_info.libs.append('multiview')


### PR DESCRIPTION
Using quirc in a project and it seems to not be included when using the `cmake_find_package` generator. Specifically, the generated file `Findopencv.cmake` does not mention quirc. I believe this is the fix.