### PR TITLE
Disable superres module for iOS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -501,6 +501,8 @@ class OpenCVConan(ConanFile):
                 opencv_libs.remove("freetype")
             if not self.options.eigen or not self.options.glog or not self.options.gflags:
                 opencv_libs.remove("sfm")
+            if str(self.settings.os) in ["iOS", "watchOS", "tvOS"]:
+                opencv_libs.remove("superres")
 
         if self.options.cuda:
             opencv_libs = ["cudaarithm",


### PR DESCRIPTION
https://github.com/opencv/opencv_contrib/blob/master/modules/superres/CMakeLists.txt#L2

Without this change compilation of the sample project for iOS that uses `opencv/4.1.1@conan/stable` will fail with error

```
ld: library not found for -lopencv_superres
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```