### PR TITLE
feat: allow custom builds using `modules` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following command both runs all the steps of the conan file, and publishes t
 | shared      | False |  [True, False] | Build shared libraries only |
 | fPIC      | True |  [True, False] | Compile with -fPIC (Linux only) |
 | contrib      | False |  [True, False] | Build OpenCV contrib from sources |
+| modules   | None | Any comma-delimited string | Select specific OpenCV modules to build |
 | jpeg      | True |  [True, False] | Build with libjpeg |
 | jpegturbo | False |  [True, False] | Build with libjpeg-turbo |
 | tiff      | True |  [True, False] | Build with libtiff |

--- a/conanfile.py
+++ b/conanfile.py
@@ -515,12 +515,12 @@ class OpenCVConan(ConanFile):
                     "xphoto",
                     "sfm"] + opencv_libs
 
-            if not self.options.freetype or not self.options.harfbuzz:
-                opencv_libs.remove("freetype")
-            if not self.options.eigen or not self.options.glog or not self.options.gflags:
-                opencv_libs.remove("sfm")
-            if str(self.settings.os) in ["iOS", "watchOS", "tvOS"]:
-                opencv_libs.remove("superres")
+                if not self.options.freetype or not self.options.harfbuzz:
+                    opencv_libs.remove("freetype")
+                if not self.options.eigen or not self.options.glog or not self.options.gflags:
+                    opencv_libs.remove("sfm")
+                if str(self.settings.os) in ["iOS", "watchOS", "tvOS"]:
+                    opencv_libs.remove("superres")
 
         # Add all cuda modules if cuda option given but no specific module list
         if self.options.cuda and not self.options.modules:


### PR DESCRIPTION
This feature takes of advantage of the [OpenCV `BUILD_LIST` flag](https://github.com/opencv/opencv/pull/9893) to allow consumers to create customized OpenCV builds using only the modules they need instead of the current default of all core or all core + all contrib. 

Example to build only the modules needed to pass the test:
```
conan create . -o opencv:modules=features2d,highgui,videoio,imgcodecs,objdetect,imgproc,core --build=missing
```

Example that adds only the contrib `face` contrib module and does not compile all of contrib:
```
conan create . -o opencv:modules=face,features2d,highgui,videoio,imgcodecs,objdetect,imgproc,core -o opencv:contrib=True --build=missing
```

Example that only compiles `core` (this will fail the test, since it relies on `objdetect`, etc):
```
conan create . -o opencv:modules=core
```

Care has been taken to ensure it builds with all the other available options, but happy to get feedback for improvements.