### PR TITLE
fix name of tiff option for test package

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -30,7 +30,7 @@ class TestPackageConan(ConanFile):
             test_images = []
             if self.options["opencv"].jpeg:
                 test_images.append('lena.jpg')
-            if self.options["opencv"].libtiff != False:
+            if self.options["opencv"].tiff != False:
                 test_images.append('normal.tiff')
                 if self.options["libtiff"].lzma != False:
                     test_images.append('lzma.tiff')


### PR DESCRIPTION
The name of the relevant option in the opencv package is `tiff` and not `libtiff` (not sure how this was previously working but breaks with Conan 1.28.1 - can't see anything relevant in the latest Conan changelog)