### PR TITLE
Patch the conanfile to make use of Visual Studion 2019 compiler

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,6 +49,11 @@ class OpenCVConan(ConanFile):
 
         shutil.rmtree(os.path.join(self._source_subfolder, '3rdparty'))
 
+        tools.replace_in_file("source_subfolder/cmake/OpenCVDetectCXXCompiler.cmake", "set(OpenCV_RUNTIME vc15)",
+                              '''set(OpenCV_RUNTIME vc15)
+elseif(MSVC_VERSION MATCHES "^192[0-9]$")
+    set(OpenCV_RUNTIME vc16)''')  
+
     def config_options(self):
         if self.settings.os == 'Windows':
             del self.options.fPIC


### PR DESCRIPTION
Updated the makefile to make use of Visual Studion 2019 without the correct compiler, the CONAN_LIB_DIRS_DSO_PACKAGE is not set; hence is not possible to use opencv in a conan project

without this patch, the OpenCV test (lena) fails to execute.