### PR TITLE
Add option with_highgui to be able to build without gui dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,8 @@ class OpenCVConan(ConanFile):
                "ffmpeg": [True, False],
                "lapack": [True, False],
                "parallel": ["tbb", "openmp", None],
-               "quirc": [True, False]}
+               "quirc": [True, False],
+               "with_highgui": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "contrib": False,
@@ -67,7 +68,8 @@ class OpenCVConan(ConanFile):
                        "ffmpeg": False,
                        "lapack": False,
                        "parallel": None,
-                       "quirc": True}
+                       "quirc": True,
+                       "with_highgui": True}
     exports_sources = ["CMakeLists.txt", "patches/*.patch"]
     exports = "LICENSE"
     generators = "cmake"
@@ -382,6 +384,9 @@ class OpenCVConan(ConanFile):
         # quirc
         cmake.definitions['WITH_QUIRC'] = self.options.quirc
 
+        # HighGUI
+        cmake.definitions['BUILD_opencv_highgui'] = self.options.with_highgui
+
         # TIFF
         cmake.definitions['BUILD_TIFF'] = False
         cmake.definitions['WITH_TIFF'] = self.options.tiff
@@ -514,6 +519,9 @@ class OpenCVConan(ConanFile):
             # https://github.com/opencv/opencv/blob/4.0.1/modules/gapi/cmake/DownloadADE.cmake#L2
             opencv_libs.append("gapi")
 
+        if not self.options.with_highgui:
+            opencv_libs.remove("highgui")
+        
         if self.options.contrib:
             opencv_libs = [
                 "aruco",

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,8 +7,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
 
-ADD_EXECUTABLE(lena  lena.cpp)
-TARGET_LINK_LIBRARIES(lena ${CONAN_LIBS})
+if(TEST_GUI)
+	ADD_EXECUTABLE(lena  lena.cpp)
+	TARGET_LINK_LIBRARIES(lena ${CONAN_LIBS})
+endif()
 
 ADD_EXECUTABLE(load-image load-image.cpp)
 TARGET_LINK_LIBRARIES(load-image ${CONAN_LIBS})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -13,6 +13,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions['TEST_GUI'] = self.options["opencv"].with_highgui
         cmake.configure()
         cmake.build()
 
@@ -26,11 +27,12 @@ class TestPackageConan(ConanFile):
         img_path = os.path.join(self.source_folder, "lena.jpg")
         shutil.copy(img_path, 'bin')
         with tools.chdir('bin'):
-            self.run('lena.exe' if self.settings.os == 'Windows' else './lena', run_environment=True)
+            if self.options["opencv"].with_highgui:
+                self.run('lena.exe' if self.settings.os == 'Windows' else './lena', run_environment=True)
             test_images = []
             if self.options["opencv"].jpeg:
                 test_images.append('lena.jpg')
-            if self.options["opencv"].libtiff != False:
+            if self.options["opencv"].tiff != False:
                 test_images.append('normal.tiff')
                 if self.options["libtiff"].lzma != False:
                     test_images.append('lzma.tiff')


### PR DESCRIPTION
Please feel free to decline if to specific of a use case. I wasn't sure myself if this would be useful for the community upstream but since we do need an OpenCV build without any graphical dependencies to be run on an edge device I figured it might be useful.